### PR TITLE
Update Default ROS 2 Distribution to ROS 2 Iron Irwini

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
-            ros2-distro: foxy
-          - os: ubuntu-20.04
-            ros2-distro: galactic
+          - os: ubuntu-22.04
+            ros2-distro: humble
+          - os: ubuntu-22.04
+            ros2-distro: iron
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v2.3.4

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
         uses: ichiro-its/ros2-build-and-test-action@main
 ```
 
-> This will be defaulted to use [ROS 2 Foxy Fitzroy](https://docs.ros.org/en/foxy/Releases/Release-Foxy-Fitzroy.html).
+> This will be defaulted to use [ROS 2 Iron Irwini](https://docs.ros.org/en/foxy/Releases/Release-Iron-Irwini.html).
 
 > It's recommended to not checkout the repository in the root directory.
 > Else, test could be failed because the package's files are mixed with the build result.
@@ -43,7 +43,7 @@ jobs:
 - name: Build and test workspace
   uses: ichiro-its/ros2-build-and-test-action@main
   with:
-    ros2-distro: dashing
+    ros2-distro: rolling
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   ros2-distro:
     description: 'The ROS 2 distribution to be used.'
     required: false
-    default: 'foxy'
+    default: 'iron'
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
This pull request updates the default ROS 2 distribution to use [ROS 2 Iron Irwini](https://docs.ros.org/en/foxy/Releases/Release-Iron-Irwini.html) and adjusts CI testing to include [Ubuntu 22.04](https://releases.ubuntu.com/jammy/) on both the `humble` and `irwini` distributions. Additionally, the `README.md` file has been updated to reflect these changes. It closes #5.