### PR TITLE
Refine Workflow Configuration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,15 +6,11 @@ on:
     branches: [main]
 jobs:
   action-test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-22.04
-            ros2-distro: humble
-          - os: ubuntu-22.04
-            ros2-distro: iron
+        ros2-distro: [humble, iron]
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,8 @@ on:
   push:
     branches: [main]
 jobs:
-  action-test:
+  build-and-test:
+    name: Build and Test
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -41,7 +42,8 @@ jobs:
           name: Install
           path: install
 
-  action-test-failed-build:
+  failed-build:
+    name: Failed Build
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout this repository
@@ -61,7 +63,8 @@ jobs:
         if: ${{ steps.action.outcome == 'success' }}
         run: false
 
-  action-test-failed-test:
+  failed-test:
+    name: Failed Test
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout this repository

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,7 @@ jobs:
   action-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-22.04
@@ -47,6 +48,7 @@ jobs:
   action-test-failure:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         package: [failed_build, failed_test]
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Action Test
+name: Test
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,26 +45,42 @@ jobs:
           name: Install
           path: install
 
-  action-test-failure:
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        package: [failed_build, failed_test]
+  action-test-failed-build:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v2.3.4
 
       - name: Only test some packages
         run: |
-          mv test/${{ matrix.package }} ${{ matrix.package }} || true
-          rm -rf examples test || true
+          mv test/failed_build failed_build
+          rm -rf examples test
 
       - name: Test the action
-        id: failedstep
+        id: action
         continue-on-error: true
         uses: ./
 
       - name: Fails if previous step has succeeded
-        if: ${{ steps.failedstep.outcome == 'success' }}
+        if: ${{ steps.action.outcome == 'success' }}
+        run: false
+
+  action-test-failed-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2.3.4
+
+      - name: Only test some packages
+        run: |
+          mv test/failed_test failed_test
+          rm -rf examples test
+
+      - name: Test the action
+        id: action
+        continue-on-error: true
+        uses: ./
+
+      - name: Fails if previous step has succeeded
+        if: ${{ steps.action.outcome == 'success' }}
         run: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,6 @@ name: Test
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 jobs:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![latest version](https://img.shields.io/github/v/release/ichiro-its/ros2-build-and-test-action)](https://github.com/ichiro-its/ros2-build-and-test-action/releases/)
 [![commits since latest version](https://img.shields.io/github/commits-since/ichiro-its/ros2-build-and-test-action/latest)](https://github.com/ichiro-its/ros2-build-and-test-action/releases/)
 [![license](https://img.shields.io/github/license/ichiro-its/ros2-build-and-test-action)](./LICENSE)
-[![test status](https://img.shields.io/github/workflow/status/ichiro-its/ros2-build-and-test-action/Action%20Test?label=test)](https://github.com/ichiro-its/ros2-build-and-test-action/actions)
+[![test status](https://img.shields.io/github/workflow/status/ichiro-its/ros2-build-and-test-action/test.yaml?label=test&branch=main)](https://github.com/ichiro-its/ros2-build-and-test-action/actions/workflows/test.yaml)
 
 This action could be used to build and test a [ROS 2](https://www.ros.org/) workspace from source.
 


### PR DESCRIPTION
This pull request makes adjustments to the workflow configuration, including the following changes:
- Renames the workflow from `Action Test` to `Test`.
- Updates it to be triggered by any pull request event.
- Refines the matrix strategy in the Build and Test job (previously named `action-test`).
- Splits the `action-test-failure` job into separate Failed Build and Failed Test jobs.