### PR TITLE
Implement Dependabot Configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
This pull request add a Dependabot configuration that check for a new version of GitHub Action dependencies. It closes #15.