### PR TITLE
Refine `.gitignore` File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
 .*
-
 !.git*
-
-build
-install
-log


### PR DESCRIPTION
This pull request updates the `.gitignore` file to exclude specific files from version control. It removes the `build`, `install`, and `log` files, which are generated during ROS 2 workspace building and testing and are not suitable for inclusion in this list.