### PR TITLE
Introduce "ROS 2 Workspace Setup" Sub-Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,32 @@ on:
   push:
     branches: [main]
 jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ros2-distro: [humble, iron]
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v4.1.1
+
+      - name: Checkout ROS 2 examples
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: ros2/examples
+          ref: ${{ matrix.ros2-distro }}
+          path: examples
+          sparse-checkout: |
+            examples/rclcpp/topics
+            examples/rclpy/topics
+
+      - name: Setup workspace
+        uses: ./setup
+        with:
+          ros2-distro: ${{ matrix.ros2-distro }}
+
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-22.04

--- a/action.yaml
+++ b/action.yaml
@@ -12,21 +12,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - shell: bash
-      run: |
-        sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-
-    - shell: bash
-      run: |
-        sudo apt update
-        sudo apt install -y python3-colcon-common-extensions python3-rosdep
-
-    - shell: bash
-      run: |
-        sudo rosdep init
-        rosdep update
-        rosdep install -y --rosdistro ${{ inputs.ros2-distro }} --from-paths .
+    - uses: ichiro-its/ros2-build-and-test-action/setup@dfe0ad86dc3adcc73f9314c8ab4d585263caa7f0
+      with:
+        ros2-distro: ${{ inputs.ros2-distro }}
 
     - shell: bash
       run: |

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -1,0 +1,29 @@
+name: ROS 2 Workspace Setup
+description: Setup tools and dependencies for a ROS 2 workspace
+author: ICHIRO ITS
+branding:
+  icon: activity
+  color: gray-dark
+inputs:
+  ros2-distro:
+    description: The ROS 2 distribution to be used.
+    required: false
+    default: iron
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list
+
+    - shell: bash
+      run: |
+        sudo apt update
+        sudo apt install -y python3-colcon-common-extensions python3-rosdep
+
+    - shell: bash
+      run: |
+        sudo rosdep init
+        rosdep update
+        rosdep install -y --rosdistro ${{ inputs.ros2-distro }} --from-paths .


### PR DESCRIPTION
This pull request introduces the following changes:
- Introduces a "ROS 2 Workspace Setup" sub-action for setting up tools and dependencies of a ROS 2 workspace.
- Uses the Setup sub-action in the main action.
- Add a Setup job in the Test workflow for testing the Setup sub-action

It closes #12.