### PR TITLE
Introduce "ROS 2 Workspace Build" Sub-Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main]
 jobs:
-  setup:
-    name: Setup
+  setup-and-build:
+    name: Setup and Build
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -28,6 +28,11 @@ jobs:
 
       - name: Setup workspace
         uses: ./setup
+        with:
+          ros2-distro: ${{ matrix.ros2-distro }}
+
+      - name: Build workspace
+        uses: ./build
         with:
           ros2-distro: ${{ matrix.ros2-distro }}
 

--- a/action.yml
+++ b/action.yml
@@ -16,10 +16,9 @@ runs:
       with:
         ros2-distro: ${{ inputs.ros2-distro }}
 
-    - shell: bash
-      run: |
-        source /opt/ros/${{ inputs.ros2-distro }}/setup.bash
-        colcon build --event-handlers console_cohesion+ --cmake-args
+    - uses: ichiro-its/ros2-build-and-test-action/build@83681337c83fd88d63d1826964a55edbaf56ea2f
+      with:
+        ros2-distro: ${{ inputs.ros2-distro }}
 
     - shell: bash
       run: |

--- a/build/action.yaml
+++ b/build/action.yaml
@@ -1,0 +1,18 @@
+name: ROS 2 Workspace Build
+description: Build packages in a ROS 2 workspace
+author: ICHIRO ITS
+branding:
+  icon: activity
+  color: gray-dark
+inputs:
+  ros2-distro:
+    description: The ROS 2 distribution to be used.
+    required: false
+    default: iron
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        source /opt/ros/${{ inputs.ros2-distro }}/setup.bash
+        colcon build --event-handlers console_cohesion+ --cmake-args


### PR DESCRIPTION
This pull request introduces the following changes:
- Introduces a "ROS 2 Workspace Build" sub-action for building packages in a ROS 2 workspace.
- Modifies the Setup job in the Test workflow to be Setup and Build job.
- Uses the Build sub-action in the main action.

It closes #22.