### PR TITLE
Correct Sparse Checkout Path for the Setup Job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,8 +23,8 @@ jobs:
           ref: ${{ matrix.ros2-distro }}
           path: examples
           sparse-checkout: |
-            examples/rclcpp/topics
-            examples/rclpy/topics
+            rclcpp/topics
+            rclpy/topics
 
       - name: Setup workspace
         uses: ./setup


### PR DESCRIPTION
This pull request addresses an issue with an incorrect path in the `sparse-checkout` input of the Setup Job. This issue was causing examples not to be checked out in the workspace and led to dependency installation problems. 

Closes #26.