### PR TITLE
Remove Upload Build Result Step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,12 +65,6 @@ jobs:
         with:
           ros2-distro: ${{ matrix.ros2-distro }}
 
-      - name: Upload build result
-        uses: actions/upload-artifact@v3.1.3
-        with:
-          name: Install
-          path: install
-
   failed-build:
     name: Failed Build
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This pull request simply removed the Upload Build Result step in the Build and Test job of Test workflow. It closes #30.