### PR TITLE
Adjust Job Names in the Test Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main]
 jobs:
-  setup-and-build:
-    name: Setup and Build
+  individual-setup-build:
+    name: Individual Setup and build
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,8 +36,8 @@ jobs:
         with:
           ros2-distro: ${{ matrix.ros2-distro }}
 
-  build-and-test:
-    name: Build and Test
+  setup-build-test:
+    name: Setup, Build, and Test
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
This pull request simply adjusted job names in the Test workflow as follows:
- `Build and Test` job into `Setup, Build, and Test` job.
- `Setup and Build` job into `Individual Setup and Build` job.