### PR TITLE
Initialize Workspace Setup Script After Workspace Setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,13 +12,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: ichiro-its/ros2-build-and-test-action/setup@dfe0ad86dc3adcc73f9314c8ab4d585263caa7f0
+    - uses: ichiro-its/ros2-build-and-test-action/setup@d80e4254f5c4722b0dcea1b73b83d434a2db069c
       with:
         ros2-distro: ${{ inputs.ros2-distro }}
 
-    - uses: ichiro-its/ros2-build-and-test-action/build@83681337c83fd88d63d1826964a55edbaf56ea2f
-      with:
-        ros2-distro: ${{ inputs.ros2-distro }}
+    - uses: ichiro-its/ros2-build-and-test-action/build@d80e4254f5c4722b0dcea1b73b83d434a2db069c
 
     - shell: bash
       run: |

--- a/build/action.yaml
+++ b/build/action.yaml
@@ -4,11 +4,6 @@ author: ICHIRO ITS
 branding:
   icon: activity
   color: gray-dark
-inputs:
-  ros2-distro:
-    description: The ROS 2 distribution to be used.
-    required: false
-    default: iron
 runs:
   using: composite
   steps:

--- a/build/action.yaml
+++ b/build/action.yaml
@@ -14,5 +14,5 @@ runs:
   steps:
     - shell: bash
       run: |
-        source /opt/ros/${{ inputs.ros2-distro }}/setup.bash
+        source install/setup.bash
         colcon build --event-handlers console_cohesion+ --cmake-args

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -27,3 +27,8 @@ runs:
         sudo rosdep init
         rosdep update
         rosdep install -y --rosdistro ${{ inputs.ros2-distro }} --from-paths .
+
+    - shell: bash
+      run: |
+        source /opt/ros/${{ inputs.ros2-distro }}/setup.bash
+        colcon build --packages-skip-regex '.*'


### PR DESCRIPTION
This pull request implements the following improvements:

- Initializes the workspace setup script after the setup by triggering `colcon build` without building any packages.
- Adjusts the Build action to source the local workspace setup script.
- Removes the unused `ros2-distro` input from the Build action.

Closes #39.