### PR TITLE
Rename `ros2-distro` Input to `distro`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros2-distro: [humble, iron]
+        distro: [humble, iron]
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v4.1.1
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: ros2/examples
-          ref: ${{ matrix.ros2-distro }}
+          ref: ${{ matrix.distro }}
           path: examples
           sparse-checkout: |
             rclcpp/topics
@@ -29,12 +29,12 @@ jobs:
       - name: Setup workspace
         uses: ./setup
         with:
-          ros2-distro: ${{ matrix.ros2-distro }}
+          distro: ${{ matrix.distro }}
 
       - name: Build workspace
         uses: ./build
         with:
-          ros2-distro: ${{ matrix.ros2-distro }}
+          distro: ${{ matrix.distro }}
 
   setup-build-test:
     name: Setup, Build, and Test
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros2-distro: [humble, iron]
+        distro: [humble, iron]
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v4.1.1
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: ros2/examples
-          ref: ${{ matrix.ros2-distro }}
+          ref: ${{ matrix.distro }}
           path: examples
           sparse-checkout: |
             rclcpp/topics
@@ -60,4 +60,4 @@ jobs:
       - name: Test the action
         uses: ./
         with:
-          ros2-distro: ${{ matrix.ros2-distro }}
+          distro: ${{ matrix.distro }}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here are the available input parameters for the ROS 2 Build and Test Workspace A
 
 | Name | Default | Description |
 | --- | --- | --- |
-| `ros2-distro` | `iron` | Specify the version of ROS 2 to be set up using this action. You can refer to the [ROS 2 Distributions](https://docs.ros.org/en/rolling/Releases.html) for information about the available distributions to be used. |
+| `ros2` | `iron` | Specify the distribution of ROS 2 to be set up using this action. You can refer to the [ROS 2 Distributions](https://docs.ros.org/en/rolling/Releases.html) for information about the available distributions to be used. |
 
 ### Examples
 
@@ -59,7 +59,7 @@ You can specify the ROS 2 distribution to be used by providing it as an input pa
 - name: Build and test
   uses: ichiro-its/ros2-build-and-test-action@v1.0.0
   with:
-    ros2-distro: rolling
+    distro: rolling
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,8 @@ branding:
   icon: activity
   color: gray-dark
 inputs:
-  ros2-distro:
-    description: The ROS 2 distribution to be used.
+  distro:
+    description: The ROS 2 distribution to be used
     required: false
     default: iron
 runs:
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: ichiro-its/ros2-build-and-test-action/setup@d80e4254f5c4722b0dcea1b73b83d434a2db069c
       with:
-        ros2-distro: ${{ inputs.ros2-distro }}
+        distro: ${{ inputs.distro }}
 
     - uses: ichiro-its/ros2-build-and-test-action/build@d80e4254f5c4722b0dcea1b73b83d434a2db069c
 

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: ichiro-its/ros2-build-and-test-action/setup@d80e4254f5c4722b0dcea1b73b83d434a2db069c
+    - uses: ichiro-its/ros2-build-and-test-action/setup@18f8d40805c2668f07b836763824d99bb6e33f9b
       with:
         distro: ${{ inputs.distro }}
 
-    - uses: ichiro-its/ros2-build-and-test-action/build@d80e4254f5c4722b0dcea1b73b83d434a2db069c
+    - uses: ichiro-its/ros2-build-and-test-action/build@18f8d40805c2668f07b836763824d99bb6e33f9b
 
     - shell: bash
       run: |

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -5,8 +5,8 @@ branding:
   icon: activity
   color: gray-dark
 inputs:
-  ros2-distro:
-    description: The ROS 2 distribution to be used.
+  distro:
+    description: The ROS 2 distribution to be used
     required: false
     default: iron
 runs:
@@ -26,9 +26,9 @@ runs:
       run: |
         sudo rosdep init
         rosdep update
-        rosdep install -y --rosdistro ${{ inputs.ros2-distro }} --from-paths .
+        rosdep install -y --rosdistro ${{ inputs.distro }} --from-paths .
 
     - shell: bash
       run: |
-        source /opt/ros/${{ inputs.ros2-distro }}/setup.bash
+        source /opt/ros/${{ inputs.distro }}/setup.bash
         colcon build --packages-skip-regex '.*'


### PR DESCRIPTION
This pull request simply renamed the `ros2-distro` input to `distro`. It closes #35.